### PR TITLE
Implement schema to validate partner fields on create partner

### DIFF
--- a/changelog.d/validate-partner-fields-on-create-view.feature
+++ b/changelog.d/validate-partner-fields-on-create-view.feature
@@ -1,0 +1,1 @@
+Validate fields on partner create view

--- a/drink_partners/partners/schemas.py
+++ b/drink_partners/partners/schemas.py
@@ -1,10 +1,4 @@
-from marshmallow import (
-    Schema,
-    ValidationError,
-    fields,
-    pre_load,
-    validate
-)
+from marshmallow import Schema, ValidationError, fields, pre_load, validate
 
 
 def validate_point(points):

--- a/drink_partners/partners/schemas.py
+++ b/drink_partners/partners/schemas.py
@@ -1,0 +1,72 @@
+from marshmallow import (
+    Schema,
+    ValidationError,
+    fields,
+    pre_load,
+    validate
+)
+
+
+def validate_point(points):
+    if len(points) != 2:
+        raise ValidationError(
+            'Points must have exactly two coordinates: [lng, lat]'
+        )
+
+
+class CoverageAreaSchema(Schema):
+    type = fields.Str(
+        required=True,
+        validate=[
+            validate.OneOf(
+                [
+                    'MultiPolygon',
+                ],
+                error='Type must be {choices}'
+            )
+        ]
+    )
+
+    coordinates = fields.List(
+        fields.List(
+            fields.List(
+                fields.List(
+                    fields.Float(), validate=[validate_point]
+                )
+            )
+        )
+    )
+
+
+class AddressSchema(Schema):
+
+    type = fields.Str(
+        required=True,
+        validate=[
+            validate.OneOf(
+                [
+                    'Point',
+                ],
+                error='Type must be {choices}'
+            )
+        ]
+    )
+    coordinates = fields.List(fields.Float(), validate=[validate_point])
+
+
+class PartnerSchema(Schema):
+
+    id = fields.Int(required=True)
+
+    tradingName = fields.Str(required=True)
+    ownerName = fields.Str(required=True)
+    document = fields.Str(required=True)
+    coverageArea = fields.Nested(CoverageAreaSchema(), required=True)
+    address = fields.Nested(AddressSchema(), required=True)
+
+    @pre_load
+    def parse_id_to_int(self, in_data, **kwargs):
+        _id = in_data.get('id')
+        if _id:
+            in_data['id'] = int(_id)
+        return in_data

--- a/drink_partners/partners/tests/conftest.py
+++ b/drink_partners/partners/tests/conftest.py
@@ -46,9 +46,7 @@ async def save_partner(mongo_database):
 
 @pytest.fixture
 def create_partner_payload():
-    return {
-        'pdvs': [partner_adega_cerveja()]
-    }
+    return partner_adega_cerveja()
 
 
 @pytest.fixture

--- a/drink_partners/partners/tests/test_schemas.py
+++ b/drink_partners/partners/tests/test_schemas.py
@@ -1,0 +1,85 @@
+import pytest
+
+from drink_partners.contrib.samples import partner_adega_cerveja
+from drink_partners.partners.schemas import PartnerSchema
+
+
+class TestPartnerSchema:
+
+    def test_schema_should_validate_with_no_errors(
+        self
+    ):
+        schema = PartnerSchema()
+        errors = schema.validate(partner_adega_cerveja())
+        assert errors == {}
+
+    @pytest.mark.parametrize('field', (
+        'id',
+        'tradingName',
+        'document',
+        'coverageArea',
+        'address',
+    ))
+    def test_schema_should_return_errors_when_missing_field(
+        self,
+        field
+    ):
+        partner = partner_adega_cerveja()
+        del partner[field]
+
+        schema = PartnerSchema()
+        errors = schema.validate(partner)
+
+        assert errors == {field: ['Missing data for required field.']}
+
+    def test_schema_should_return_error_when_address_has_invalid_type(self):
+        partner = partner_adega_cerveja()
+
+        partner['address']['type'] = 'invalid-type'
+
+        schema = PartnerSchema()
+        errors = schema.validate(partner)
+        assert errors == {'address': {'type': ['Type must be Point']}}
+
+    def test_schema_should_return_error_when_address_has_invalid_point(self):
+        partner = partner_adega_cerveja()
+
+        partner['address']['coordinates'] = [0, 1, 2]
+
+        schema = PartnerSchema()
+        errors = schema.validate(partner)
+
+        assert errors == {
+            'address': {
+                'coordinates': [
+                    'Points must have exactly two coordinates: [lng, lat]'
+                ]
+            }
+        }
+
+    def test_schema_should_return_error_coverage_area_has_invalid_multipolygon(self): # noqa
+        partner = partner_adega_cerveja()
+
+        partner['coverageArea']['coordinates'] = [[0, 1]]
+
+        schema = PartnerSchema()
+        errors = schema.validate(partner)
+
+        assert errors == {
+            'coverageArea': {
+                'coordinates': {
+                    0: {
+                        0: ['Not a valid list.'],
+                        1: ['Not a valid list.']
+                    }
+                }
+            }
+        }
+
+    def test_schema_should_return_error_when_address_has_id_as_str(self):
+        partner = partner_adega_cerveja()
+        partner['id'] = '1'
+        schema = PartnerSchema()
+        errors = schema.validate(partner)
+
+        assert errors == {}

--- a/drink_partners/partners/tests/views/test_create_view.py
+++ b/drink_partners/partners/tests/views/test_create_view.py
@@ -13,19 +13,64 @@ class TestProductCreateView:
             assert response.status == 201
 
             response_json = await response.json()
-            assert response_json == create_partner_payload['pdvs']
+            assert response_json == create_partner_payload
 
     async def test_should_return_bad_request_when_no_payload(
         self,
         client,
-        create_partner_url,
-        create_partner_payload,
+        create_partner_url
     ):
         async with client.post(
             create_partner_url,
             json=None
         ) as response:
             assert response.status == 400
+
+            response_json = await response.json()
+
+            assert response_json['error_code'] == 'bad_request'
+            assert response_json['error_message'] == (
+                'Invalid payload: {} error: '
+                'Expecting value: line 1 column 1 (char 0)'
+            )
+
+    async def test_should_return_bad_request_when_partner_has_invalid_field(
+        self,
+        client,
+        create_partner_url,
+        create_partner_payload,
+    ):
+
+        del create_partner_payload['id']
+
+        async with client.post(
+            create_partner_url,
+            json=create_partner_payload
+        ) as response:
+            assert response.status == 400
+
+            response_json = await response.json()
+
+            assert response_json['error_code'] == 'bad_request'
+            assert response_json['error_message'] == (
+                'Invalid partner payload: '
+                '{\'id\': [\'Missing data for required field.\']}'
+            )
+
+    async def test_should_return_bad_request_when_empty_json(
+        self,
+        client,
+        create_partner_url
+    ):
+        async with client.post(
+            create_partner_url,
+            json={}
+        ) as response:
+            assert response.status == 400
+            response_json = await response.json()
+
+            assert response_json['error_code'] == 'bad_request'
+            assert response_json['error_message'] == 'Empty JSON payload: {}'
 
     async def test_should_conflict_when_partner_already_exists(
         self,

--- a/drink_partners/partners/views/partner_get_view.py
+++ b/drink_partners/partners/views/partner_get_view.py
@@ -3,8 +3,7 @@ import logging
 
 from drink_partners.contrib.exceptions import BadRequest, NotFound
 from drink_partners.contrib.response import JSONResponse
-
-from .generic import PartnerView
+from drink_partners.partners.views.generic import PartnerView
 
 logger = logging.getLogger(__name__)
 

--- a/drink_partners/partners/views/partner_search_view.py
+++ b/drink_partners/partners/views/partner_search_view.py
@@ -5,8 +5,7 @@ from geojson import Point
 
 from drink_partners.contrib.exceptions import BadRequest, NotFound
 from drink_partners.contrib.response import JSONResponse
-
-from .generic import PartnerView
+from drink_partners.partners.views.generic import PartnerView
 
 logger = logging.getLogger(__name__)
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,6 +2,7 @@ aiohttp==3.6.2
 aiohttp-swagger==1.0.14
 geojson==2.5.0
 gunicorn==20.0.0
+marshmallow==3.5.1
 motor==2.1.0
 ramos==1.4.0
 simple-settings==0.19.1


### PR DESCRIPTION
**Description**

* Add marshmallow lib to validate partner fields;
* Create partner validation schema and validate payload fields before creating a partner;
* Refactor `PartnerCreateView` to accept only one partner per request.