### PR TITLE
Use update with upsert instead of insert when creating partner

### DIFF
--- a/changelog.d/use-update-with-upsert-instead-of-insert-when-creating-partner.bugfix
+++ b/changelog.d/use-update-with-upsert-instead-of-insert-when-creating-partner.bugfix
@@ -1,0 +1,1 @@
+Use update with upsert instead of insert when creating partner

--- a/drink_partners/extensions/partners/mongodb.py
+++ b/drink_partners/extensions/partners/mongodb.py
@@ -34,10 +34,14 @@ class PartnersMongoDbBackend(SingletonCreateMixin, PartnersBackend):
                 partner_id=payload['id'],
                 document=payload['document']
             )
+        partner_id = int(payload['id'])
+        payload['id'] = partner_id
 
-        payload['id'] = int(payload['id'])
-        await self.partners_collection.insert_one(payload)
-        del payload['_id']
+        await self.partners_collection.update_one(
+            {'id': partner_id},
+            {'$set': payload},
+            upsert=True
+        )
 
     async def search_nearest_by_coordinate(self, coordinate):
         criteria = {


### PR DESCRIPTION
**Description**

Use `update_one` passing upsert true instead of `insert` when creating a partner.

Why?

If someone tries to save a partner with same id, it will duplicate and cause problems.