### PR TITLE
Remove Safety lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ install:
 # Run the unit test
 script:
   - make lint
-  - make check-vulnerabilities
   - make test-coverage
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,3 @@ release-major: ## Create major release
 	bump2version major --dry-run --no-tag --no-commit --list | grep new_version= | sed -e 's/new_version=//' | SIMPLE_SETTINGS=drink_partners.settings.test xargs -n 1 towncrier --yes --version
 	git commit -am 'Update CHANGELOG'
 	bump2version major
-
-check-vulnerabilities:
-	safety check -r requirements/base.txt

--- a/changelog.d/remove-safety-lib.feature
+++ b/changelog.d/remove-safety-lib.feature
@@ -1,0 +1,1 @@
+Remove safety lib

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,4 +3,3 @@ flake8==3.7.9
 isort==4.3.21
 pytest-aiohttp==0.3.0
 pytest-cov==2.8.1
-safety==1.8.5


### PR DESCRIPTION
**Description**

Remove Safety lib from project and steps to check possible vulnerabilities. 

Why?

GitHub founds it as a security issue.